### PR TITLE
fix for occasional crash in QGraphicsSceneBspTree

### DIFF
--- a/src/ConnectionGraphicsObject.cpp
+++ b/src/ConnectionGraphicsObject.cpp
@@ -257,8 +257,8 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
     {
       Q_ASSERT(this == _scene._temporaryConn);
       // remove this from the scene
-      delete _scene._temporaryConn;
       _scene._temporaryConn = nullptr;
+      deleteLater();
     }
 
     return;
@@ -275,16 +275,14 @@ mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
   {
     node->resetReactionToConnection();
     Q_ASSERT(this == _scene._temporaryConn);
-
-    delete _scene._temporaryConn;
     _scene._temporaryConn = nullptr;
+    deleteLater();
   }
   else if (state().requiresPort())
   {
     Q_ASSERT(this == _scene._temporaryConn);
-
-    delete _scene._temporaryConn;
     _scene._temporaryConn = nullptr;
+    deleteLater();
   }
 }
 


### PR DESCRIPTION
QObject::deleteLater() applied instead of deleting QObject with 'delete this' inside it's event handler (ConnectionGraphicsObject::mouseReleaseEvent)